### PR TITLE
Add headless behaviour when generating png from puml file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as file:
 
 setup(
     name="eaiscenarioreporter",
-    version="0.0.19",
+    version="0.0.20",
     description="Turns folder of gherkin feature files into a docx file.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/test/feature/new_test.feature
+++ b/test/feature/new_test.feature
@@ -1,0 +1,14 @@
+@TF-01 @test
+Feature: New Test feature
+
+  As An End User
+  I want to test the reporter
+  So that I will know if it's working
+
+  !!Workflow: ../workflows/test1.puml
+
+  @event
+  Scenario:
+    Given I write a workflow reference
+    When I generate the report
+    Then The workflow picture is added

--- a/test/workflows/test1.puml
+++ b/test/workflows/test1.puml
@@ -1,0 +1,22 @@
+@startuml
+'https://plantuml.com/use-case-diagram
+
+:Main MyAdmin: as Admin
+(Use the application) as (Use)
+
+MyUser -> (Start)
+MyUser --> (Use)
+
+Admin ---> (Use)
+
+note right of Admin : This is an example.
+
+note right of (Use)
+A note can also
+be on several lines
+end note
+
+note "This note is connected\nto several objects." as N2
+(Start) .. N2
+N2 .. (Use)
+@enduml


### PR DESCRIPTION
Add headless behaviour when generating png from puml file
Add a check first behaviour before generating png from puml file: if the png exists, don't generate the file