### PR TITLE
Fix circular import

### DIFF
--- a/featurereporter/__init__.py
+++ b/featurereporter/__init__.py
@@ -3,6 +3,5 @@
 # -*- Author: E.Aivayan -*-
 
 from .featurereporter import main
-from .reportgenerator import ExportUtilities
 
-__all__ = [main, ExportUtilities]
+__all__ = [main]

--- a/featurereporter/featurereporter.py
+++ b/featurereporter/featurereporter.py
@@ -13,7 +13,7 @@ from logging.handlers import RotatingFileHandler
 from PIL import ImageTk, Image
 from tkinter import filedialog, Toplevel, messagebox
 
-from featurereporter import ExportUtilities
+from .reportgenerator import ExportUtilities
 
 log = logging.getLogger(__name__)
 

--- a/featurereporter/featurereporter.py
+++ b/featurereporter/featurereporter.py
@@ -6,18 +6,22 @@ import argparse
 import os
 import sys
 import tempfile
-import tkinter as tk
+try:
+    import tkinter as tk
+    from PIL import ImageTk, Image
+    from tkinter import filedialog, Toplevel, messagebox
+    GUI_ENABLED = True
+except ImportError:
+    GUI_ENABLED = False
 
 from logging.handlers import RotatingFileHandler
 
-from PIL import ImageTk, Image
-from tkinter import filedialog, Toplevel, messagebox
 
 from .reportgenerator import ExportUtilities
 
 log = logging.getLogger(__name__)
 
-LICENCE = """ ExportUtilities  Copyright (C) 2021  E.Aivayan
+LICENCE = """ ExportUtilities  Copyright (C) 2022  E.Aivayan
     This program comes with ABSOLUTELY NO WARRANTY.
     This is free software, and you are welcome to redistribute it under certain conditions.
 
@@ -231,7 +235,7 @@ def main():
     parser.add_argument("--tag", help="Invariant pointing to a user story")
     parser.add_argument("--title", help="The document's title")
     parser.add_argument("--repository", help="The folder where the feature files are")
-    parser.add_argument("--output", help="")
+    parser.add_argument("--output", help="The filename the docu")
     parser.add_argument("--execution",
                         help="Behave plain test output in order to "
                              "also print the last execution result")
@@ -248,8 +252,16 @@ def main():
         )
         and not args.license
     ):
-        app = Application()
-        app.run()
+        if GUI_ENABLED:
+            app = Application()
+            app.run()
+        else:
+            print(f"""{LICENCE}
+    Run with --license option to display the full licence
+    
+    --> tkinter cannot be imported. GUI cannot be launched.
+    Please use the full command line to generate report.""")
+
     else:
         print(args.license)
         if args.license is not None and args.license:

--- a/featurereporter/reportgenerator.py
+++ b/featurereporter/reportgenerator.py
@@ -6,17 +6,19 @@ import platform
 import re
 import subprocess
 import tempfile
+import logging
+import PIL
+
 from pathlib import Path
 from shutil import copyfile
 from typing import Tuple
-
-import PIL
 from behave.parser import parse_file
 from docx import Document
 from docx.shared import Cm
 from matplotlib import pyplot as plt
 
-from featurereporter.featurereporter import log
+
+log = logging.getLogger(__name__)
 
 
 class ExportUtilities:
@@ -78,10 +80,7 @@ class ExportUtilities:
                  "h3": 3,
                  "h4": 4,
                  "h5": 5}
-        if self.__include_result:
-            return level[level_name] + 1
-        else:
-            return level[level_name]
+        return level[level_name] + 1 if self.__include_result else level[level_name]
 
     def create_application_documentation(self, report_file=None, output_file_name="demo.docx"):
         """

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as file:
 
 setup(
     name="eaiscenarioreporter",
-    version="0.1.1",
+    version="0.1.3",
     description="Turns folder of gherkin feature files into a docx file.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as file:
 
 setup(
     name="eaiscenarioreporter",
-    version="0.1.00",
+    version="0.1.1",
     description="Turns folder of gherkin feature files into a docx file.",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# Fix
**defect**: Cannot import module in headless linux

**rootcause**: tkinter module is missing and no handling is done on import error.

**fix**: add a try/except clause around tk** imports and set a global variable for running module preventing the GUI launch in headless mode.