### PR TITLE
Fix csv formatter: all columns are quoted

### DIFF
--- a/featurereporter/csvformatter.py
+++ b/featurereporter/csvformatter.py
@@ -1,10 +1,11 @@
 # -*- Product under GNU GPL v3 -*-
 # -*- Author: E.Aivayan -*-
+import csv
+
 from behave.formatter.base import Formatter
 from behave.model import Status
 from csv import DictWriter
 import re
-
 
 
 class EaiCsv(Formatter):
@@ -89,7 +90,8 @@ class EaiCsv(Formatter):
                                           "scenario_id",
                                           "scenario",
                                           "status",
-                                          "order"])
+                                          "order"],
+                            quoting=csv.QUOTE_ALL)
         writer.writeheader()
         writer.writerows(self.__result)
 
@@ -210,7 +212,8 @@ class EaiCsvFull(Formatter):
                                           "scenario_tags",
                                           "scenario_description",
                                           "scenario_is_outline",
-                                          "scenario_steps"])
+                                          "scenario_steps"],
+                            quoting=csv.QUOTE_ALL)
         writer.writeheader()
         writer.writerows([{"epic": item} for item in self.__epics])
         writer.writerows(self.__features)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as file:
 
 setup(
     name="eaiscenarioreporter",
-    version="0.3.0",
+    version="0.3.1",
     description="Turns folder of gherkin feature files into a docx file.",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# Fix

## Issues
- some columns are misinterpreted by spreadsheet software

## Root cause
- these columns were not surronded by double quote

## Fix
- add csv.QUOTE_ALL in the csv writer