### PR TITLE
Fix User Story wrong capture

### DIFF
--- a/featurereporter/reportgenerator.py
+++ b/featurereporter/reportgenerator.py
@@ -361,15 +361,15 @@ class ExportUtilities:
             description = "\n".join(feature.description)
             # Capture user story and format
 
-            description = re.sub(r"as([ \w\"']*)",
+            description = re.sub(r"as([ \w\"'\.\-]*)",
                                  lambda x:f"<b>As</b> {x.group(1)} <br />",
                                  description,
                                  flags=re.IGNORECASE)
-            description = re.sub(r"i want([ \w\"']*)",
+            description = re.sub(r"i want([ \w\"'\.\-]*)",
                                  lambda x: f"<b>I want</b> {x.group(1)} <br />",
                                  description,
                                  flags=re.IGNORECASE)
-            description = re.sub(r"so that([ \w\"']*)",
+            description = re.sub(r"so that([ \w\"'\.\-]*)",
                                  lambda x: f"<b>So that</b> {x.group(1)} <br />",
                                  description,
                                  flags=re.IGNORECASE)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as file:
 
 setup(
     name="eaiscenarioreporter",
-    version="0.4.0",
+    version="0.4.1",
     description="Turns folder of gherkin feature files into a docx file.",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# Defect
The story contains newline in the middle of the text.

## Root cause

The capturing regex does not include the dot character.

## Fix

Add dot character to the capturing group.
Also add the minus character to the capturing group.

The capturing group is `([ \w\"'\.\-]*)`.