### PR TITLE
Fix Table not rendering

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as file:
 
 setup(
     name="eaiscenarioreporter",
-    version="0.4.1",
+    version="0.4.2",
     description="Turns folder of gherkin feature files into a docx file.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/test/feature/test_table.feature
+++ b/test/feature/test_table.feature
@@ -1,0 +1,41 @@
+Feature: Test feature
+
+  As An End User
+  I want to test the reporter
+  So that I will know if it's working
+
+  !!Workflow: ../workflows/test.puml
+
+  * One rule
+  * another one
+  * a rule followed by a table
+  | A tabular | to test |
+  | --------- | ------- |
+  | one| two|
+
+  Free text in the feature description
+
+  $ Title
+  * text
+  | A tabular | to test |
+  | --------- | ------- |
+  | one| two|
+
+  $$ Sub title
+  | A tabular | to test |
+  | --------- | ------- |
+  | one| two|
+  | A tabular | to test |
+  | one| two|
+
+  $$ Sub title
+  1. test one
+  1. test two
+  | A tabular | to test |
+  | --------- | ------- |
+  | one| two|
+
+  Scenario:
+    Given I write a workflow reference
+    When I generate the report
+    Then The workflow picture is added


### PR DESCRIPTION
# Defect
Markdown table is not rendered as a table

## Root cause
The table was not separated from the previous object (here a list).

## Fix
Detect lines starting with a pipe character and add a newline before and after the block.

# Additional feature
In feature description, the dollar symbol ($) at the line beginning is converted to a hash symbol (#). Behave ignores the line starting with a dollar symbol (python's comment).